### PR TITLE
Fix poetry build system

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,5 +10,5 @@ ktrain = "^0.30.0"
 cached-path = "^1.1.1"
 
 [build-system]
-requires = ["poetry-core>=1.0.0"]
-build-backend = "poetry.core.masonry.api"
+requires = ["poetry"]
+build-backend = "poetry.masonry.api"


### PR DESCRIPTION
For whatever reason, `poetry init` creates a key, `[build-system]` that can't be used to pip install the repo from the git URL. I make the simple change that should fix that.