### PR TITLE
Add colab link to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,13 @@
+<a href="https://colab.research.google.com/github/PathwayCommons/pathway-abstract-classifier/blob/main/Tutorial.ipynb" target="_parent"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/></a>
+
 # pathway-abstract-classifier
+
 A tool to classify articles with pathway content in terms of whether they are suitable for [Biofactoid](https://biofactoid.org/). 
 
 ## Usage 
 
 This repository requires Python 3.7 or later. 
+
 ### Installation
 ```sh
 git clone https://github.com/PathwayCommons/pathway-abstract-classifier.git
@@ -12,7 +16,9 @@ pip install -r requirements.txt
 ```
 
 ### Quickstart 
+
 Basic example; model is loaded and then used to classify one article that clearly belongs in Biofactoid and one that clearly does not. On the last line, we check that it gets this correct (where an output of 1 indicates article belongs in Biofactoid, 0 indicates it does not). 
+
 ```py
 import ktrain
 from cached_path import cached_path

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ predictions = model.predict(texts)
 assert predictions == [1,0]
 ```
 
-See this [tutorial](https://github.com/PathwayCommons/pathway-abstract-classifier/blob/main/Tutorial.ipynb) for a more detailed guide on potential usage. Importantly, this tutorial shows how to conduct threshold-moving, which you can learn more about [here](https://deepchecks.com/glossary/classification-threshold/). Also consider taking a look at the Ktrain [documentation](https://amaiya.github.io/ktrain/index.html) and [repo](https://github.com/amaiya/ktrain) which contains some very good tutorials. 
+See the [tutorial](https://github.com/PathwayCommons/pathway-abstract-classifier/blob/main/Tutorial.ipynb) (or open it in [Colab](https://colab.research.google.com/github/PathwayCommons/pathway-abstract-classifier/blob/main/Tutorial.ipynb)) for a more detailed guide on potential usage. Importantly, this tutorial shows how to conduct threshold-moving, which you can learn more about [here](https://deepchecks.com/glossary/classification-threshold/). Also consider taking a look at the Ktrain [documentation](https://amaiya.github.io/ktrain/index.html) and [repo](https://github.com/amaiya/ktrain) which contains some very good tutorials. 
 
 ## Citing 
 [Todo?] 

--- a/Tutorial.ipynb
+++ b/Tutorial.ipynb
@@ -2,49 +2,51 @@
   "cells": [
     {
       "cell_type": "markdown",
+      "id": "b06d9c74",
       "metadata": {
-        "id": "view-in-github",
-        "colab_type": "text"
+        "colab_type": "text",
+        "id": "view-in-github"
       },
       "source": [
-        "<a href=\"https://colab.research.google.com/github/PathwayCommons/pathway-abstract-classifier/blob/update_tutorial/Tutorial.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+        "<a href=\"https://colab.research.google.com/github/PathwayCommons/pathway-abstract-classifier/blob/main/Tutorial.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
       ]
     },
     {
       "cell_type": "markdown",
+      "id": "4e2cc07a",
       "metadata": {
         "id": "4e2cc07a"
       },
       "source": [
         "<h1> Using PubMed Article Classifier - Tutorial </h1>"
-      ],
-      "id": "4e2cc07a"
+      ]
     },
     {
       "cell_type": "markdown",
-      "source": [
-        "Set up environment"
-      ],
+      "id": "kYvQH7DNUoio",
       "metadata": {
         "id": "kYvQH7DNUoio"
       },
-      "id": "kYvQH7DNUoio"
+      "source": [
+        "Set up environment"
+      ]
     },
     {
       "cell_type": "code",
       "execution_count": 10,
+      "id": "8781f9db",
       "metadata": {
         "id": "8781f9db"
       },
       "outputs": [],
       "source": [
         "!git clone -q https://github.com/PathwayCommons/pathway-abstract-classifier.git"
-      ],
-      "id": "8781f9db"
+      ]
     },
     {
       "cell_type": "code",
       "execution_count": 11,
+      "id": "4sTpfqU138VU",
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -54,8 +56,8 @@
       },
       "outputs": [
         {
-          "output_type": "stream",
           "name": "stdout",
+          "output_type": "stream",
           "text": [
             "/content/pathway-abstract-classifier/pathway-abstract-classifier\n"
           ]
@@ -67,22 +69,22 @@
         "!pip install -q -r requirements.txt\n",
         "# Currently necessary to get this to run in Colab environment\n",
         "!pip install -q --upgrade google-cloud-storage"
-      ],
-      "id": "4sTpfqU138VU"
+      ]
     },
     {
       "cell_type": "markdown",
+      "id": "c0ad5e77",
       "metadata": {
         "id": "c0ad5e77"
       },
       "source": [
         "Below we import necessary libraries, turn on AMP (optional) and load our model"
-      ],
-      "id": "c0ad5e77"
+      ]
     },
     {
       "cell_type": "code",
       "execution_count": 12,
+      "id": "e8ac548a",
       "metadata": {
         "id": "e8ac548a"
       },
@@ -102,22 +104,22 @@
         "# Load model\n",
         "model_path = cached_path(\"https://github.com/PathwayCommons/pathway-abstract-classifier/releases/download/pretrained-models/title_abstract_model.zip\", extract_archive=True)\n",
         "predictor = ktrain.load_predictor(model_path)"
-      ],
-      "id": "e8ac548a"
+      ]
     },
     {
       "cell_type": "markdown",
+      "id": "bc55499c",
       "metadata": {
         "id": "bc55499c"
       },
       "source": [
         "Here we read in our validation data, then pre-process our input data from this and make predictions. Finally, we pre-process our existing labels to be able to calculate performance metrics"
-      ],
-      "id": "bc55499c"
+      ]
     },
     {
       "cell_type": "code",
       "execution_count": 13,
+      "id": "1918321c",
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -127,8 +129,8 @@
       },
       "outputs": [
         {
-          "output_type": "stream",
           "name": "stdout",
+          "output_type": "stream",
           "text": [
             "CPU times: user 28.4 s, sys: 4.66 s, total: 33 s\n",
             "Wall time: 2min 31s\n"
@@ -155,22 +157,22 @@
         "# pre process existing labels \n",
         "df['class']=df['class'].astype('bool')\n",
         "y_val=df['class'].to_numpy()"
-      ],
-      "id": "1918321c"
+      ]
     },
     {
       "cell_type": "markdown",
+      "id": "14bbc95d",
       "metadata": {
         "id": "14bbc95d"
       },
       "source": [
         "Checking performance now"
-      ],
-      "id": "14bbc95d"
+      ]
     },
     {
       "cell_type": "code",
       "execution_count": 14,
+      "id": "7aa222a1",
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -180,8 +182,8 @@
       },
       "outputs": [
         {
-          "output_type": "stream",
           "name": "stdout",
+          "output_type": "stream",
           "text": [
             "[[797  45]\n",
             " [ 47 153]]\n",
@@ -208,22 +210,22 @@
         "print(confusion_matrix((y_val),predictions))\n",
         "print(classification_report((y_val), predictions))\n",
         "print(matthews_corrcoef((y_val), predictions))"
-      ],
-      "id": "7aa222a1"
+      ]
     },
     {
       "cell_type": "markdown",
+      "id": "6a9840cb",
       "metadata": {
         "id": "6a9840cb"
       },
       "source": [
         "Let's try altering confidence threshold now (this will make our classifier more conservative)"
-      ],
-      "id": "6a9840cb"
+      ]
     },
     {
       "cell_type": "code",
       "execution_count": 15,
+      "id": "ec9d9d2c",
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -233,8 +235,8 @@
       },
       "outputs": [
         {
-          "output_type": "stream",
           "name": "stdout",
+          "output_type": "stream",
           "text": [
             "[[838   4]\n",
             " [121  79]]\n",
@@ -259,34 +261,34 @@
         "print(confusion_matrix((y_val),conf_predictions))\n",
         "print(classification_report((y_val), conf_predictions))\n",
         "print(matthews_corrcoef((y_val), conf_predictions))"
-      ],
-      "id": "ec9d9d2c"
+      ]
     },
     {
       "cell_type": "markdown",
+      "id": "1f3d7866",
       "metadata": {
         "id": "1f3d7866"
       },
       "source": [
         "Now let's try a single example (with an explanation)"
-      ],
-      "id": "1f3d7866"
+      ]
     },
     {
       "cell_type": "code",
       "execution_count": 16,
+      "id": "1f181454",
       "metadata": {
         "id": "1f181454"
       },
       "outputs": [],
       "source": [
         "!pip install -q https://github.com/amaiya/eli5/archive/refs/heads/tfkeras_0_10_1.zip"
-      ],
-      "id": "1f181454"
+      ]
     },
     {
       "cell_type": "code",
       "execution_count": 17,
+      "id": "555cdb35",
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -296,8 +298,8 @@
       },
       "outputs": [
         {
-          "output_type": "stream",
           "name": "stdout",
+          "output_type": "stream",
           "text": [
             "1\n"
           ]
@@ -307,12 +309,12 @@
         "title = \"YTHDC1-mediated augmentation of miR-30d in repressing pancreatic tumorigenesis via attenuation of RUNX1-induced transcriptional activation of Warburg effect\"\n",
         "abstract = \"Pancreatic ductal adenocarcinoma (PDAC) is one of the most lethal human cancers. It thrives in a malnourished environment; however, little is known about the mechanisms by which PDAC cells actively promote aerobic glycolysis to maintain their metabolic needs. Gene Expression Omnibus (GEO) was used to identify differentially expressed miRNAs. The expression pattern of miR-30d in normal and PDAC tissues was studied by in situ hybridization. The role of miR-30d/RUNX1 in vitro and in vivo was evaluated by CCK8 assay and clonogenic formation as well as transwell experiment, subcutaneous xenograft model and liver metastasis model, respectively. Glucose uptake, ATP and lactate production were tested to study the regulatory effect of miR-30d/RUNX1 on aerobic glycolysis in PDAC cells. Quantitative real-time PCR, western blot, Chip assay, promoter luciferase activity, RIP, MeRIP, and RNA stability assay were used to explore the molecular mechanism of YTHDC1/miR-30d/RUNX1 in PDAC. Here, we discover that miR-30d expression was remarkably decreased in PDAC tissues and associated with good prognosis, contributed to the suppression of tumor growth and metastasis, and attenuation of Warburg effect. Mechanistically, the m6A reader YTHDC1 facilitated the biogenesis of mature miR-30d via m6A-mediated regulation of mRNA stability. Then, miR-30d inhibited aerobic glycolysis through regulating SLC2A1 and HK1 expression by directly targeting the transcription factor RUNX1, which bound to the promoters of the SLC2A1 and HK1 genes. Moreover, miR-30d was clinically inversely correlated with RUNX1, SLC2A1 and HK1, which function as adverse prognosis factors for overall survival in PDAC tissues. Overall, we demonstrated that miR-30d is a functional and clinical tumor-suppressive gene in PDAC. Our findings further uncover that miR-30d is a novel target for YTHDC1 through m6A modification, and miR-30d represses pancreatic tumorigenesis via suppressing aerobic glycolysis.\"\n",
         "print(predictor.predict(\" \".join([title, sep_token, abstract])))"
-      ],
-      "id": "555cdb35"
+      ]
     },
     {
       "cell_type": "code",
       "execution_count": 18,
+      "id": "c658e3f7",
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/",
@@ -323,11 +325,7 @@
       },
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
-            "text/plain": [
-              "<IPython.core.display.HTML object>"
-            ],
             "text/html": [
               "\n",
               "    <style>\n",
@@ -470,24 +468,27 @@
               "\n",
               "\n",
               "\n"
+            ],
+            "text/plain": [
+              "<IPython.core.display.HTML object>"
             ]
           },
+          "execution_count": 18,
           "metadata": {},
-          "execution_count": 18
+          "output_type": "execute_result"
         }
       ],
       "source": [
         "predictor.explain(\" \".join([title, sep_token, abstract]))"
-      ],
-      "id": "c658e3f7"
+      ]
     }
   ],
   "metadata": {
     "accelerator": "GPU",
     "colab": {
+      "include_colab_link": true,
       "name": "Copy of Tutorial.ipynb",
-      "provenance": [],
-      "include_colab_link": true
+      "provenance": []
     },
     "kernelspec": {
       "display_name": "Python 3",

--- a/Tutorial.ipynb
+++ b/Tutorial.ipynb
@@ -40,7 +40,7 @@
       },
       "outputs": [],
       "source": [
-        "!git clone -q https://github.com/PathwayCommons/pathway-abstract-classifier.git"
+        "!git clone https://github.com/PathwayCommons/pathway-abstract-classifier.git"
       ]
     },
     {
@@ -66,9 +66,9 @@
       "source": [
         "# This cell may throw some errors which you can safely ignore\n",
         "%cd pathway-abstract-classifier\n",
-        "!pip install -q -r requirements.txt\n",
+        "!pip install -r requirements.txt\n",
         "# Currently necessary to get this to run in Colab environment\n",
-        "!pip install -q --upgrade google-cloud-storage"
+        "!pip install --upgrade google-cloud-storage"
       ]
     },
     {
@@ -282,7 +282,7 @@
       },
       "outputs": [],
       "source": [
-        "!pip install -q https://github.com/amaiya/eli5/archive/refs/heads/tfkeras_0_10_1.zip"
+        "!pip install https://github.com/amaiya/eli5/archive/refs/heads/tfkeras_0_10_1.zip"
       ]
     },
     {


### PR DESCRIPTION
Quick PR, which:

- Adds the colab link back to the readme (looks like it got dropped at some point?)
- Adds the colab badge to top of readme so its easy to find (and this is usually where people put badges)
- Uses correct colab link in tutorial notebook (the previous link was to a closed branch, not `main`).
- I also removed all the `-q` arguments in the tutorial. We don't want these commands to be silent because then if they fail you have no idea why.