### PR TITLE
CI workflow updates to trigger codecov upload

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -16,7 +16,7 @@ jobs:
     #----------------------------------------------
     strategy:
       matrix:
-        python-version: ["3.8", "3.9"]
+        python-version: [3.8, 3.9]
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
I used strings instead of numbers to declare the python versions, which led to skipping the codecov upload.